### PR TITLE
Make calculate endpoint use form data

### DIFF
--- a/backend/app/calc.py
+++ b/backend/app/calc.py
@@ -1,28 +1,51 @@
-def calculate_metrics(scenario):
+"""Financial calculation utilities for the backend API."""
+
+from typing import Mapping, Any
+import numpy_financial as npf
+
+
+def calculate_metrics(scenario: Mapping[str, Any]) -> dict:
+    """Calculate investment metrics from the provided scenario."""
     try:
-        # Convert Pydantic model to dictionary
-        p = scenario.dict() if hasattr(scenario, 'dict') else scenario
-        
-        # Use mock data for now to get the frontend working
-        # TODO: Implement real calculations later
-        monthly_payment = 1440.0
-        noi = 18000.0
-        cap_rate = 6.0
-        cash_flow = 7200.0
-        cash_on_cash = 12.0
-        stock_value = 129435.0
-        npv = 45000.0
-        irr = 8.5
-        
+        p = scenario.dict() if hasattr(scenario, "dict") else dict(scenario)
+
+        # Mortgage payment
+        monthly_rate = p["interest_rate"] / 100 / 12
+        payments = p["loan_years"] * 12
+        monthly_payment = (
+            p["loan_amount"]
+            * (monthly_rate * (1 + monthly_rate) ** payments)
+            / ((1 + monthly_rate) ** payments - 1)
+        )
+
+        # Net operating income
+        gross_income = p["rent"] * 12
+        vacancy_loss = gross_income * (p["vacancy_rate"] / 100)
+        operating_expenses = p["property_tax"] + p["insurance"] + p["maintenance"]
+        noi = gross_income - vacancy_loss - operating_expenses
+
+        cap_rate = noi / p["purchase_price"] * 100
+        cash_flow = noi - monthly_payment * 12
+        cash_on_cash = cash_flow / p["down_payment"] * 100 if p["down_payment"] else 0
+        stock_value = p["down_payment"] * (1 + p["stock_return_rate"] / 100) ** p["years"]
+
+        discount_rate = p["stock_return_rate"] / 100
+        cash_flows = [-p["down_payment"]] + [cash_flow] * p["years"]
+        npv = npf.npv(discount_rate, cash_flows)
+        irr = npf.irr(cash_flows) * 100
+        if irr != irr or irr in (float("inf"), float("-inf")):
+            irr = 0.0
+
         return {
-            "monthly_payment": monthly_payment,
-            "NOI": noi,
-            "CapRate": cap_rate,
-            "CashFlow": cash_flow,
-            "CashOnCash": cash_on_cash,
-            "StockValue": stock_value,
-            "NPV": npv,
-            "IRR": irr,
+            "monthly_payment": float(monthly_payment),
+            "NOI": float(noi),
+            "CapRate": float(cap_rate),
+            "CashFlow": float(cash_flow),
+            "CashOnCash": float(cash_on_cash),
+            "StockValue": float(stock_value),
+            "NPV": float(npv),
+            "IRR": float(irr),
         }
-    except Exception as e:
-        raise Exception(f"Calculation error: {str(e)}") 
+
+    except Exception as e:  # pragma: no cover - defensive catch all
+        raise Exception(f"Calculation error: {str(e)}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,3 +27,4 @@ typing_extensions==4.14.1
 urllib3==2.5.0
 uvicorn==0.35.0
 xgboost==3.0.2
+numpy-financial==1.0.0

--- a/backend/tests/test_calculate.py
+++ b/backend/tests/test_calculate.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from app.main import app
+
+client = TestClient(app)
+
+base_scenario = {
+    "purchase_price": 300000,
+    "down_payment": 60000,
+    "loan_amount": 240000,
+    "interest_rate": 6.5,
+    "loan_years": 30,
+    "property_tax": 3000,
+    "insurance": 1200,
+    "maintenance": 1500,
+    "vacancy_rate": 5,
+    "rent": 2000,
+    "appreciation_rate": 3,
+    "stock_return_rate": 8,
+    "years": 10,
+}
+
+
+def test_calculate_returns_varying_values():
+    resp1 = client.post("/calculate", json=base_scenario)
+    assert resp1.status_code == 200
+    data1 = resp1.json()
+    # change rent to ensure output differs
+    scenario2 = base_scenario.copy()
+    scenario2["rent"] = 2500
+    resp2 = client.post("/calculate", json=scenario2)
+    assert resp2.status_code == 200
+    data2 = resp2.json()
+    assert data1 != data2
+    assert data2["NOI"] > data1["NOI"]
+
+
+def test_monthly_payment_calculation():
+    resp = client.post("/calculate", json=base_scenario)
+    assert resp.status_code == 200
+    data = resp.json()
+    monthly_rate = base_scenario["interest_rate"] / 100 / 12
+    payments = base_scenario["loan_years"] * 12
+    expected_payment = base_scenario["loan_amount"] * (
+        monthly_rate * (1 + monthly_rate) ** payments
+    ) / ((1 + monthly_rate) ** payments - 1)
+    assert abs(data["monthly_payment"] - expected_payment) < 0.01
+
+


### PR DESCRIPTION
## Summary
- implement real calculations in `calc.py`
- require `numpy-financial` for IRR/NPV
- add tests exercising `/calculate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c37336bf08321a9d5ce4015950cdf