### PR TITLE
Modernize UI theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <title>RentIO - Investment Analyzer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,11 +8,39 @@ import { calculateScenario, askLLM } from './api';
 
 const theme = createTheme({
   palette: {
+    mode: 'light',
     primary: {
-      main: '#1976d2',
+      main: '#0052CC',
     },
     secondary: {
-      main: '#dc004e',
+      main: '#2EC4B6',
+    },
+    background: {
+      default: '#f8fbff',
+    },
+  },
+  typography: {
+    fontFamily: `'Poppins', sans-serif`,
+    h6: {
+      fontWeight: 600,
+    },
+  },
+  components: {
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 12,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
+        },
+      },
     },
   },
 });
@@ -58,7 +86,15 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <AppBar position="static" elevation={0} sx={{ backgroundColor: 'white', color: 'text.primary' }}>
+      <AppBar
+        position="static"
+        elevation={0}
+        sx={{
+          background: 'linear-gradient(90deg, #0052CC 0%, #2EC4B6 100%)',
+          color: '#fff',
+          boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+        }}
+      >
         <Toolbar>
           <CalculateIcon sx={{ mr: 2 }} />
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontWeight: 600 }}>

--- a/frontend/src/components/KPISummary.tsx
+++ b/frontend/src/components/KPISummary.tsx
@@ -347,7 +347,7 @@ const KPISummary: React.FC<KPISummaryProps> = ({ results, llmResponse, formData 
 
   if (!results) {
     return (
-      <Paper elevation={3} sx={{ p: 3, height: 'fit-content' }}>
+      <Paper elevation={0} sx={{ p: 4, backgroundColor: '#fff' }}>
         <Typography variant="h5" component="h2" gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
           Investment Analysis
         </Typography>
@@ -427,7 +427,7 @@ const KPISummary: React.FC<KPISummaryProps> = ({ results, llmResponse, formData 
   ];
 
   return (
-    <Paper elevation={3} sx={{ p: 3, height: 'fit-content' }}>
+    <Paper elevation={0} sx={{ p: 4, backgroundColor: '#fff' }}>
       <Typography variant="h5" component="h2" gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
         Investment Analysis
       </Typography>

--- a/frontend/src/components/ScenarioForm.tsx
+++ b/frontend/src/components/ScenarioForm.tsx
@@ -54,7 +54,7 @@ const ScenarioForm: React.FC<ScenarioFormProps> = ({ onCalculate, loading }) => 
   };
 
   return (
-    <Paper elevation={3} sx={{ p: 3, height: 'fit-content' }}>
+    <Paper elevation={0} sx={{ p: 4, backgroundColor: '#fff' }}>
       <Typography variant="h5" component="h2" gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
         Investment Parameters
       </Typography>
@@ -233,7 +233,8 @@ const ScenarioForm: React.FC<ScenarioFormProps> = ({ onCalculate, loading }) => 
               py: 1.5,
               fontSize: '1.1rem',
               fontWeight: 600,
-              minWidth: 200
+              minWidth: 200,
+              background: 'linear-gradient(90deg, #0052CC 0%, #2EC4B6 100%)'
             }}
           >
             {loading ? 'Calculating...' : 'Calculate Investment'}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,14 @@
-:root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html, body, #root {
+  height: 100%;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  font-family: 'Poppins', sans-serif;
+  background: linear-gradient(180deg, #f8fbff 0%, #ecf2fc 100%);
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+a {
+  color: inherit;
+  text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- use Poppins font and rename page to RentIO
- apply a soft gradient background and adjust theme
- style cards and buttons with modern look

## Testing
- `npm run build`
- `python -m py_compile app/*.py`
- `pytest` (no tests found)

------
https://chatgpt.com/codex/tasks/task_e_687c3753d0548321b3398f0448ddb311