### PR TITLE
Improve KPI calculations and add DSCR metric

### DIFF
--- a/backend/app/calc.py
+++ b/backend/app/calc.py
@@ -1,19 +1,65 @@
-def calculate_metrics(scenario):
+from typing import Dict
+import numpy as np
+
+
+def _monthly_mortgage_payment(loan_amount: float, annual_rate: float, years: int) -> float:
+    """Calculate standard monthly mortgage payment."""
+    r = annual_rate / 100 / 12
+    n = years * 12
+    if r == 0:
+        return loan_amount / n
+    return loan_amount * (r * (1 + r) ** n) / ((1 + r) ** n - 1)
+
+
+def _irr(cash_flows):
+    """Compute internal rate of return using numpy-financial if available."""
     try:
-        # Convert Pydantic model to dictionary
-        p = scenario.dict() if hasattr(scenario, 'dict') else scenario
-        
-        # Use mock data for now to get the frontend working
-        # TODO: Implement real calculations later
-        monthly_payment = 1440.0
-        noi = 18000.0
-        cap_rate = 6.0
-        cash_flow = 7200.0
-        cash_on_cash = 12.0
-        stock_value = 129435.0
-        npv = 45000.0
-        irr = 8.5
-        
+        import numpy_financial as npf  # type: ignore
+        return npf.irr(cash_flows) * 100
+    except Exception:
+        # Fallback simple approximation
+        return np.irr(cash_flows) * 100
+
+
+def calculate_metrics(scenario) -> Dict[str, float]:
+    """Return a set of investment metrics calculated from the scenario."""
+    try:
+        data = scenario.dict() if hasattr(scenario, "dict") else scenario
+
+        # Mortgage
+        monthly_payment = _monthly_mortgage_payment(
+            data["loan_amount"], data["interest_rate"], data["loan_years"]
+        )
+        annual_debt_service = monthly_payment * 12
+
+        # Income calculations
+        gross_income = data["rent"] * 12
+        vacancy_loss = gross_income * (data["vacancy_rate"] / 100)
+        operating_expenses = data["property_tax"] + data["insurance"] + data["maintenance"]
+        noi = gross_income - vacancy_loss - operating_expenses
+
+        cap_rate = (noi / data["purchase_price"]) * 100
+
+        cash_flow = noi - annual_debt_service
+
+        cash_on_cash = (cash_flow / data["down_payment"]) * 100 if data["down_payment"] else 0
+
+        # Stock market comparison
+        stock_value = data["down_payment"] * (1 + data["stock_return_rate"] / 100) ** data["years"]
+
+        # Basic NPV using a fixed discount rate
+        discount_rate = 0.10
+        npv = -data["down_payment"]
+        for year in range(1, data["years"] + 1):
+            npv += cash_flow / (1 + discount_rate) ** year
+
+        # Internal rate of return
+        cash_flows = [-data["down_payment"]] + [cash_flow] * data["years"]
+        irr = _irr(cash_flows)
+
+        # Debt service coverage ratio
+        dscr = noi / annual_debt_service if annual_debt_service else 0
+
         return {
             "monthly_payment": monthly_payment,
             "NOI": noi,
@@ -23,6 +69,7 @@ def calculate_metrics(scenario):
             "StockValue": stock_value,
             "NPV": npv,
             "IRR": irr,
+            "DSCR": dscr,
         }
-    except Exception as e:
-        raise Exception(f"Calculation error: {str(e)}") 
+    except Exception as e:  # pragma: no cover - simple error propagation
+        raise Exception(f"Calculation error: {str(e)}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,3 +27,4 @@ typing_extensions==4.14.1
 urllib3==2.5.0
 uvicorn==0.35.0
 xgboost==3.0.2
+numpy-financial==1.0.0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ interface CalculationResult {
   CapRate: number;
   CashFlow: number;
   CashOnCash: number;
+  DSCR: number;
   StockValue: number;
   NPV: number;
   IRR: number;

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -9,6 +9,7 @@ const mockCalculation = (data: any) => ({
   CapRate: 6.00,
   CashFlow: 7200.00,
   CashOnCash: 12.00,
+  DSCR: 1.20,
   StockValue: 129435.00,
   NPV: 45000.00,
   IRR: 8.50,

--- a/frontend/src/components/KPISummary.tsx
+++ b/frontend/src/components/KPISummary.tsx
@@ -304,6 +304,37 @@ const KPISummary: React.FC<KPISummaryProps> = ({ results, llmResponse, formData 
         };
       }
     },
+    DSCR: {
+      title: 'Debt Service Coverage Ratio',
+      definition: 'Measures the property\'s ability to cover its debt obligations from operating income.',
+      calculation: [
+        'Calculate Net Operating Income (NOI)',
+        'Calculate Annual Debt Service: Monthly Payment × 12',
+        'Divide NOI by Annual Debt Service',
+        'DSCR = NOI ÷ Debt Service'
+      ],
+      insights: [
+        'DSCR above 1.25 is typically preferred by lenders',
+        'Improve DSCR by increasing rent or reducing expenses',
+        'A DSCR below 1 indicates negative cash flow after debt payments',
+        'Monitor DSCR annually to ensure loan compliance'
+      ],
+      icon: <AccountBalanceIcon />,
+      getActualCalculation: (results, formData) => {
+        const annualDebt = results.monthly_payment * 12;
+        const dscr = results.NOI / annualDebt;
+
+        return {
+          steps: [
+            `NOI = ${formatCurrency(results.NOI)}`,
+            `Annual Debt Service = ${formatCurrency(results.monthly_payment)} × 12 = ${formatCurrency(annualDebt)}`,
+            `DSCR = ${formatCurrency(results.NOI)} ÷ ${formatCurrency(annualDebt)}`,
+            `DSCR = ${dscr.toFixed(2)}`
+          ],
+          finalValue: dscr.toFixed(2)
+        };
+      }
+    },
     StockValue: {
       title: 'Stock Investment Value',
       definition: 'The projected value of investing the same amount in the stock market over the same time period.',
@@ -371,6 +402,9 @@ const KPISummary: React.FC<KPISummaryProps> = ({ results, llmResponse, formData 
     if (type === 'irr') {
       return value >= 8 ? 'success' : value >= 6 ? 'warning' : 'error';
     }
+    if (type === 'dscr') {
+      return value >= 1.25 ? 'success' : value >= 1 ? 'warning' : 'error';
+    }
     return 'default';
   };
 
@@ -409,6 +443,13 @@ const KPISummary: React.FC<KPISummaryProps> = ({ results, llmResponse, formData 
       value: `${results.CashOnCash.toFixed(1)}%`,
       icon: <PercentIcon />,
       color: 'default' as const
+    },
+    {
+      key: 'DSCR',
+      title: 'DSCR',
+      value: results.DSCR.toFixed(2),
+      icon: <AccountBalanceIcon />,
+      color: getChipColor(results.DSCR, 'dscr') as any
     },
     {
       key: 'NPV',


### PR DESCRIPTION
## Summary
- implement full KPI calculations in the backend
- add `numpy-financial` dependency
- extend API and frontend to include DSCR
- show DSCR card in KPI summary with color logic

## Testing
- `pytest`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687c378c75288321bfde46bf714d9a87