### PR TITLE
Add scenario switching

### DIFF
--- a/frontend/src/components/ScenarioForm.tsx
+++ b/frontend/src/components/ScenarioForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Paper,
   Typography,
@@ -20,32 +20,19 @@ import {
 } from '@mui/icons-material';
 
 interface ScenarioFormProps {
+  formData: any;
+  onFormDataChange: (data: any) => void;
   onCalculate: (data: any) => void;
   loading: boolean;
 }
 
-const ScenarioForm: React.FC<ScenarioFormProps> = ({ onCalculate, loading }) => {
-  const [formData, setFormData] = useState({
-    purchase_price: 300000,
-    down_payment: 60000,
-    loan_amount: 240000,
-    interest_rate: 6.5,
-    loan_years: 30,
-    property_tax: 3000,
-    insurance: 1200,
-    maintenance: 1500,
-    vacancy_rate: 5,
-    rent: 2000,
-    appreciation_rate: 3,
-    stock_return_rate: 8,
-    years: 10
-  });
+const ScenarioForm: React.FC<ScenarioFormProps> = ({ formData, onFormDataChange, onCalculate, loading }) => {
 
   const handleInputChange = (field: string, value: number) => {
-    setFormData(prev => ({
-      ...prev,
+    onFormDataChange({
+      ...formData,
       [field]: value
-    }));
+    });
   };
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/frontend/src/components/ScenarioSwitcher.tsx
+++ b/frontend/src/components/ScenarioSwitcher.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Tabs, Tab, Box } from '@mui/material';
+
+interface ScenarioSwitcherProps {
+  scenarios: { name: string }[];
+  activeIndex: number;
+  onChange: (index: number) => void;
+}
+
+const ScenarioSwitcher: React.FC<ScenarioSwitcherProps> = ({ scenarios, activeIndex, onChange }) => {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Tabs
+        value={activeIndex}
+        onChange={(e, val) => onChange(val)}
+        variant="fullWidth"
+      >
+        {scenarios.map((s, idx) => (
+          <Tab key={idx} label={s.name} />
+        ))}
+      </Tabs>
+    </Box>
+  );
+};
+
+export default ScenarioSwitcher;


### PR DESCRIPTION
## Summary
- add `ScenarioSwitcher` tabs for toggling named scenarios
- manage scenarios in App state and update ScenarioForm accordingly
- update `ScenarioForm` to be fully controlled by parent

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ca029a684832192af3f10876d9f09