### PR TITLE
Add lightweight LLM chat assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A monorepo for a React and FastAPI application that compares real estate investm
 
 - **Interactive calculators** for metrics such as Net Operating Income, Cap Rate, Cash Flow, Cash-on-Cash Return, Internal Rate of Return (IRR), and Net Present Value (NPV).
 - **Scenario comparisons** allowing users to adjust inputs like purchase price, mortgage terms, vacancy rate and more, then view both real estate and stock performance side by side.
-- **LLM integration** for answering "what‑if" questions about any scenario using OpenAI's API.
+- **LLM integration** for answering "what‑if" questions using a lightweight local model with optional OpenAI fallback.
+- **Chat assistant** lets you ask follow-up questions like "What if appreciation drops 2%?" and receive plain‑language advice.
 - **React frontend** with live updates and charting.
 - **FastAPI backend** providing calculation endpoints and optional machine‑learning forecasts.
 
@@ -16,7 +17,7 @@ A monorepo for a React and FastAPI application that compares real estate investm
 backend/
   app/
     calc.py        # financial calculations (currently mock values)
-    llm.py         # wrapper around OpenAI API
+    llm.py         # local LLM helper with optional OpenAI fallback
     main.py        # FastAPI routes
     models.py      # placeholder for future data models
   requirements.txt
@@ -42,6 +43,16 @@ python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload
+```
+
+The backend will use a small local LLM by default (`google/flan-t5-small`).
+To use a different model or the OpenAI API, set these environment variables:
+
+```bash
+# optional: override the local model
+export LOCAL_LLM_MODEL="google/flan-t5-small"
+# optional: use OpenAI instead of the local model
+export OPENAI_API_KEY=your-key
 ```
 
 ### Frontend

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -1,19 +1,59 @@
-import openai
-import os
+"""Utility to generate advice using a lightweight local LLM with optional OpenAI fallback."""
 
-def get_llm_response(scenario, question):
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, pipeline
+except Exception:  # pragma: no cover - transformers may not be installed during tests
+    AutoModelForSeq2SeqLM = None  # type: ignore
+    AutoTokenizer = None  # type: ignore
+    pipeline = None  # type: ignore
+
+import openai
+
+_local_pipe = None
+
+
+def _load_local_model(model_name: str):
+    """Load a small transformers model for CPU inference."""
+    global _local_pipe
+    if _local_pipe is None:
+        if AutoModelForSeq2SeqLM is None:
+            raise RuntimeError("Transformers not installed")
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = AutoModelForSeq2SeqLM.from_pretrained(model_name)
+        _local_pipe = pipeline("text2text-generation", model=model, tokenizer=tokenizer)
+    return _local_pipe
+
+
+def get_llm_response(scenario: Any, question: str) -> str:
+    """Return an advice string for the given scenario and user question."""
     api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        return "OpenAI API key not set."
-    openai.api_key = api_key
-    prompt = f"""
-    You are a financial advisor. Here is a real estate vs. stock scenario:
-    Scenario: {scenario}
-    User question: {question}
-    Please provide a clear, concise answer with reasoning.
-    """
-    response = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}]
+    if api_key:
+        openai.api_key = api_key
+        prompt = (
+            "You are a financial advisor. Here is a real estate vs. stock scenario:\n"
+            f"Scenario: {scenario}\n"
+            f"User question: {question}\n"
+            "Provide a clear, concise answer with reasoning."
+        )
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message["content"]
+
+    # Use local model
+    model_name = os.getenv("LOCAL_LLM_MODEL", "google/flan-t5-small")
+    pipe = _load_local_model(model_name)
+    prompt = (
+        "You are a financial advisor. "
+        f"Scenario: {scenario}. "
+        f"Question: {question}. "
+        "Answer in a short and helpful way."
     )
-    return response.choices[0].message["content"] 
+    result = pipe(prompt, max_new_tokens=128)[0]["generated_text"]
+    return result.strip()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,9 @@ jiter==0.10.0
 joblib==1.5.1
 numpy==2.3.1
 openai==1.97.0
+pillow==10.3.0
+transformers==4.40.2
+sentencepiece==0.2.0
 pydantic==2.11.7
 pydantic_core==2.33.2
 requests==2.32.4

--- a/frontend/src/components/LLMChat.tsx
+++ b/frontend/src/components/LLMChat.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Box, TextField, Button, Paper, Typography } from '@mui/material';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface LLMChatProps {
+  messages: ChatMessage[];
+  onSend: (message: string) => Promise<void>;
+}
+
+const LLMChat: React.FC<LLMChatProps> = ({ messages, onSend }) => {
+  const [input, setInput] = useState('');
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+    await onSend(input.trim());
+    setInput('');
+  };
+
+  return (
+    <Paper elevation={0} sx={{ p: 2, mt: 2 }}>
+      <Typography variant="h6" gutterBottom>
+        Chat with Advisor
+      </Typography>
+      <Box sx={{ maxHeight: 200, overflowY: 'auto', mb: 1 }}>
+        {messages.map((msg, idx) => (
+          <Box key={idx} sx={{ mb: 1 }}>
+            <Typography variant="subtitle2" color={msg.role === 'user' ? 'primary' : 'secondary'}>
+              {msg.role === 'user' ? 'You' : 'Advisor'}:
+            </Typography>
+            <Typography variant="body2">{msg.content}</Typography>
+          </Box>
+        ))}
+      </Box>
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <TextField
+          fullWidth
+          size="small"
+          placeholder="Ask a question..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyPress={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleSend();
+            }
+          }}
+        />
+        <Button variant="contained" onClick={handleSend}>Send</Button>
+      </Box>
+    </Paper>
+  );
+};
+
+export default LLMChat;


### PR DESCRIPTION
## Summary
- integrate an open-source LLM with optional OpenAI fallback
- add `LLMChat` React component and chat support in the app
- update backend requirements for transformers
- document how to use the local model

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ca0a2be6883218b09a51d6f1aebaf