### PR TITLE
Add local LLM chat assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A monorepo for a React and FastAPI application that compares real estate investm
 
 - **Interactive calculators** for metrics such as Net Operating Income, Cap Rate, Cash Flow, Cash-on-Cash Return, Internal Rate of Return (IRR), and Net Present Value (NPV).
 - **Scenario comparisons** allowing users to adjust inputs like purchase price, mortgage terms, vacancy rate and more, then view both real estate and stock performance side by side.
-- **LLM integration** for answering "what‑if" questions about any scenario using OpenAI's API.
+- **LLM integration** for answering "what‑if" questions about any scenario using OpenAI's API or a local CPU model.
 - **React frontend** with live updates, time-series plots, and bar/pie charts for detailed comparisons.
 - **FastAPI backend** providing calculation endpoints and optional machine‑learning forecasts.
 
@@ -62,6 +62,20 @@ npm run dev
 ```
 
 This runs the backend and frontend concurrently for easy development.
+
+### Local Chat Assistant
+
+To run the built-in chat assistant without any external API keys you need a
+small `gguf` model compatible with [`llama-cpp-python`](https://github.com/abetlen/llama-cpp-python).
+Download a quantized model (for example from Hugging Face) and set its path:
+
+```bash
+export LOCAL_LLM_MODEL_PATH=/path/to/model.gguf
+pip install -r backend/requirements.txt
+```
+
+The `/chat` API endpoint will now generate answers locally using the CPU. Adjust
+`LLAMA_THREADS` if you want to control how many threads the model uses.
 
 ## Project Status
 

--- a/backend/app/local_llm.py
+++ b/backend/app/local_llm.py
@@ -1,0 +1,50 @@
+import os
+from functools import lru_cache
+from typing import Any, Mapping
+
+from llama_cpp import Llama
+
+
+@lru_cache(maxsize=1)
+def _load_model() -> Llama:
+    """Load the local Llama model from ``LOCAL_LLM_MODEL_PATH``."""
+    model_path = os.getenv("LOCAL_LLM_MODEL_PATH")
+    if not model_path:
+        raise RuntimeError("LOCAL_LLM_MODEL_PATH environment variable not set")
+    n_threads = int(os.getenv("LLAMA_THREADS", "4"))
+    return Llama(model_path=model_path, n_ctx=2048, n_threads=n_threads)
+
+
+def get_chat_response(scenario: Mapping[str, Any], question: str) -> str:
+    """Generate a chat style response using the local LLM.
+
+    Parameters
+    ----------
+    scenario: Mapping[str, Any]
+        Scenario inputs describing the investment.
+    question: str
+        Arbitrary user question about the scenario.
+
+    Returns
+    -------
+    str
+        The assistant's response or an error message if the model
+        is unavailable.
+    """
+    try:
+        llm = _load_model()
+    except Exception as exc:  # pragma: no cover - simple error path
+        return f"Local LLM not available: {exc}"  # keep short for API
+
+    prompt = (
+        "You are a helpful financial assistant. "
+        f"Here is a real estate scenario: {scenario}. "
+        f"Question: {question}\nAnswer in a concise paragraph."
+    )
+
+    result = llm.create_chat_completion(
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.7,
+        max_tokens=256,
+    )
+    return result["choices"][0]["message"]["content"].strip()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 import logging
 from .calc import calculate_metrics
 from .llm import get_llm_response
+from .local_llm import get_chat_response
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -67,4 +68,15 @@ def llm_response(req: LLMRequest):
     try:
         return {"response": get_llm_response(req.scenario, req.question)}
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e)) 
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.post("/chat")
+def chat_response(req: LLMRequest):
+    """Chat endpoint powered by a local CPU LLM."""
+    try:
+        response = get_chat_response(req.scenario.model_dump(), req.question)
+        return {"response": response}
+    except Exception as e:
+        logger.error("Error in chat endpoint: %s", e, exc_info=True)
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,3 +28,4 @@ urllib3==2.5.0
 uvicorn==0.35.0
 xgboost==3.0.2
 pytest==8.2.2
+llama-cpp-python==0.2.68

--- a/backend/tests/test_local_llm.py
+++ b/backend/tests/test_local_llm.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.local_llm import get_chat_response
+
+
+def test_get_chat_response_without_model(monkeypatch):
+    monkeypatch.delenv("LOCAL_LLM_MODEL_PATH", raising=False)
+    resp = get_chat_response({}, "Hi")
+    assert "Local LLM not available" in resp

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Calculate as CalculateIcon } from '@mui/icons-material';
 import ScenarioForm from './components/ScenarioForm';
 import ScenarioSwitcher from './components/ScenarioSwitcher';
 import KPISummary from './components/KPISummary';
+import ChatAssistant from './components/ChatAssistant';
 import { calculateScenario, askLLM } from './api';
 
 const theme = createTheme({
@@ -164,6 +165,7 @@ function App() {
           {/* Right Column - Investment Analysis */}
           <Box sx={{ order: { xs: 1, lg: 2 } }}>
             <KPISummary results={results} llmResponse={llmResponse} formData={currentFormData} />
+            <ChatAssistant scenario={currentFormData} />
           </Box>
         </Box>
       </Container>

--- a/frontend/src/__tests__/ChatAssistant.test.tsx
+++ b/frontend/src/__tests__/ChatAssistant.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { vi } from 'vitest'
+import ChatAssistant from '../components/ChatAssistant'
+import * as api from '../api'
+
+vi.mock('../api')
+
+const mockedAsk = vi.mocked(api.askLLM)
+
+beforeEach(() => {
+  mockedAsk.mockResolvedValue('answer')
+})
+
+test('sends question to askLLM and displays answer', async () => {
+  render(<ChatAssistant scenario={{}} />)
+  const input = screen.getByLabelText(/ask a question/i)
+  fireEvent.change(input, { target: { value: 'Hello' } })
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+  expect(mockedAsk).toHaveBeenCalledWith({}, 'Hello')
+  await screen.findByText('answer')
+})

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -26,9 +26,9 @@ export async function calculateScenario(data: any) {
 
 export async function askLLM(scenario: any, question: string) {
   try {
-    const res = await axios.post(`${API_URL}/llm`, { scenario, question });
+    const res = await axios.post(`${API_URL}/chat`, { scenario, question });
     return res.data.response;
   } catch (error) {
     return "I'm sorry, the AI assistant is not available right now. Please try again later.";
   }
-} 
+}

--- a/frontend/src/components/ChatAssistant.tsx
+++ b/frontend/src/components/ChatAssistant.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react'
+import { Box, TextField, Button, Paper, Typography } from '@mui/material'
+import { askLLM } from '../api'
+
+interface Props {
+  scenario: any
+}
+
+const ChatAssistant: React.FC<Props> = ({ scenario }) => {
+  const [question, setQuestion] = useState('')
+  const [answer, setAnswer] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleAsk = async () => {
+    if (!question.trim()) return
+    setLoading(true)
+    const resp = await askLLM(scenario, question)
+    setAnswer(resp)
+    setLoading(false)
+  }
+
+  return (
+    <Paper sx={{ p: 2, mt: 4 }}>
+      <Typography variant="h6" gutterBottom>
+        Chat Assistant
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2 }}>
+        <TextField
+          fullWidth
+          label="Ask a question"
+          value={question}
+          onChange={e => setQuestion(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleAsk()}
+        />
+        <Button variant="contained" onClick={handleAsk} disabled={loading}>
+          Ask
+        </Button>
+      </Box>
+      {answer && (
+        <Typography sx={{ mt: 2 }}>{answer}</Typography>
+      )}
+    </Paper>
+  )
+}
+
+export default ChatAssistant


### PR DESCRIPTION
## Summary
- integrate lightweight CPU LLM via `llama-cpp-python`
- expose `/chat` endpoint in FastAPI using local model
- provide React `ChatAssistant` component and tests
- update API helper to hit `/chat`
- document running the chat assistant and update requirements

## Testing
- `python3 -m pip install -r backend/requirements.txt --quiet`
- `npm install --silent` in `frontend`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ca623c5908321a211a907c1aa409f