### PR TITLE
Enable dark mode across UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { calculateScenario, askLLM } from './api';
 
 const theme = createTheme({
   palette: {
-    mode: 'light',
+    mode: 'dark',
     primary: {
       main: '#0052CC',
     },
@@ -17,7 +17,8 @@ const theme = createTheme({
       main: '#2EC4B6',
     },
     background: {
-      default: '#f8fbff',
+      default: '#121212',
+      paper: '#1e1e1e',
     },
   },
   typography: {

--- a/frontend/src/components/KPISummary.tsx
+++ b/frontend/src/components/KPISummary.tsx
@@ -348,7 +348,7 @@ const KPISummary: React.FC<KPISummaryProps> = ({ results, llmResponse, formData 
 
   if (!results) {
     return (
-      <Paper elevation={0} sx={{ p: 4, backgroundColor: '#fff' }}>
+      <Paper elevation={0} sx={{ p: 4, bgcolor: 'background.paper' }}>
         <Typography variant="h5" component="h2" gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
           Investment Analysis
         </Typography>
@@ -428,7 +428,7 @@ const KPISummary: React.FC<KPISummaryProps> = ({ results, llmResponse, formData 
   ];
 
   return (
-    <Paper elevation={0} sx={{ p: 4, backgroundColor: '#fff' }}>
+    <Paper elevation={0} sx={{ p: 4, bgcolor: 'background.paper' }}>
       <Typography variant="h5" component="h2" gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
         Investment Analysis
       </Typography>

--- a/frontend/src/components/ScenarioForm.tsx
+++ b/frontend/src/components/ScenarioForm.tsx
@@ -58,7 +58,7 @@ const ScenarioForm: React.FC<ScenarioFormProps> = ({ formData, onFormDataChange,
   };
 
   return (
-    <Paper elevation={0} sx={{ p: 4, backgroundColor: '#fff' }}>
+    <Paper elevation={0} sx={{ p: 4, bgcolor: 'background.paper' }}>
       <Typography variant="h5" component="h2" gutterBottom sx={{ fontWeight: 600, mb: 3 }}>
         Investment Parameters
       </Typography>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,7 +5,7 @@ html, body, #root {
 body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
-  background: linear-gradient(180deg, #f8fbff 0%, #ecf2fc 100%);
+  background: linear-gradient(180deg, #121212 0%, #1e1e1e 100%);
 }
 
 a {


### PR DESCRIPTION
## Summary
- switch MUI theme to `dark`
- use theme background color for Paper components
- update global CSS background gradient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d18b278208321b78865d35e1efdf1