### PR TITLE
Add local LLM chat assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ backend/
   app/
     calc.py        # financial calculations (currently mock values)
     llm.py         # wrapper around OpenAI API
+    local_llm.py   # utilities for running a local model
     main.py        # FastAPI routes
     models.py      # placeholder for future data models
   requirements.txt
@@ -62,6 +63,22 @@ npm run dev
 ```
 
 This runs the backend and frontend concurrently for easy development.
+
+## Local LLM Chat Assistant
+
+The backend can run a lightweight CPU-based language model using
+`llama-cpp-python`. The first time you hit the `/local_llm` endpoint the model
+weights will be downloaded from Hugging Face into `backend/models/`. See
+`local_llm.py` for details. This allows experimenting with LLM responses without
+relying on OpenAI.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:8000/local_llm \
+  -H "Content-Type: application/json" \
+  -d '{"scenario": {...}, "question": "Is this a good investment?"}'
+```
 
 ## Project Status
 

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -1,10 +1,13 @@
 import openai
 import os
 
+
 def get_llm_response(scenario, question):
+    """Call the OpenAI API to answer the user's question."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         return "OpenAI API key not set."
+
     openai.api_key = api_key
     prompt = f"""
     You are a financial advisor. Here is a real estate vs. stock scenario:
@@ -14,6 +17,6 @@ def get_llm_response(scenario, question):
     """
     response = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": prompt}]
+        messages=[{"role": "user", "content": prompt}],
     )
-    return response.choices[0].message["content"] 
+    return response.choices[0].message["content"]

--- a/backend/app/local_llm.py
+++ b/backend/app/local_llm.py
@@ -1,0 +1,51 @@
+"""Utilities for interacting with a local CPU-based language model."""
+
+from pathlib import Path
+from functools import lru_cache
+from typing import Optional
+
+from huggingface_hub import hf_hub_download
+from llama_cpp import Llama
+
+
+MODEL_REPO = "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF"
+MODEL_FILE = "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
+
+
+def download_model(model_dir: Path) -> Path:
+    """Download the GGUF model if it's not already present."""
+    model_dir.mkdir(parents=True, exist_ok=True)
+    model_path = model_dir / MODEL_FILE
+    if not model_path.exists():
+        hf_hub_download(repo_id=MODEL_REPO, filename=MODEL_FILE, local_dir=model_dir, local_dir_use_symlinks=False)
+    return model_path
+
+
+class LocalLLM:
+    """Simple wrapper around a llama-cpp model."""
+
+    def __init__(self, model_path: Path, n_gpu_layers: int = 0, n_ctx: int = 2048):
+        self.llm = Llama(model_path=str(model_path), n_gpu_layers=n_gpu_layers, n_ctx=n_ctx)
+
+    def generate(self, prompt: str, max_tokens: int = 256) -> str:
+        result = self.llm(prompt, max_tokens=max_tokens, stop=["</s>"])
+        return result["choices"][0]["text"].strip()
+
+
+@lru_cache(maxsize=1)
+def get_local_llm(model_dir: Optional[Path] = None) -> LocalLLM:
+    model_dir = model_dir or Path("models")
+    model_path = download_model(model_dir)
+    return LocalLLM(model_path)
+
+
+def get_local_llm_response(scenario, question: str) -> str:
+    """Generate a response from the local model given the scenario."""
+    prompt = (
+        "You are a financial advisor. Here is a real estate vs. stock scenario:\n"
+        f"Scenario: {scenario}\n"
+        f"Question: {question}\n"
+        "Answer in a short paragraph."
+    )
+    llm = get_local_llm()
+    return llm.generate(prompt)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ import math
 import logging
 from .calc import calculate_metrics
 from .llm import get_llm_response
+from .local_llm import get_local_llm_response
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -77,4 +78,13 @@ def llm_response(req: LLMRequest):
     try:
         return {"response": get_llm_response(req.scenario, req.question)}
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e)) 
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.post("/local_llm")
+def local_llm_response(req: LLMRequest):
+    """Respond to the user's question using the local LLM."""
+    try:
+        return {"response": get_local_llm_response(req.scenario, req.question)}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,3 +29,5 @@ uvicorn==0.35.0
 xgboost==3.0.2
 pytest==8.2.2
 numpy-financial==1.0.0
+huggingface-hub==0.23.2
+llama-cpp-python==0.2.71

--- a/backend/tests/test_local_llm.py
+++ b/backend/tests/test_local_llm.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app
+from app import local_llm
+
+client = TestClient(app)
+
+
+def test_get_local_llm_response_mock(monkeypatch):
+    class DummyLLM:
+        def generate(self, prompt, max_tokens=256):
+            assert "Scenario" in prompt
+            return "dummy answer"
+
+    monkeypatch.setattr(local_llm, "get_local_llm", lambda model_dir=None: DummyLLM())
+    resp = local_llm.get_local_llm_response({}, "What is ROI?")
+    assert "dummy answer" in resp
+
+
+def test_local_llm_endpoint(monkeypatch):
+    monkeypatch.setattr(local_llm, "get_local_llm_response", lambda s, q: "dummy")
+    import app.main as main_module
+    monkeypatch.setattr(main_module, "get_local_llm_response", lambda s, q: "dummy")
+    scenario = {
+        "purchase_price": 1,
+        "down_payment": 1,
+        "loan_amount": 0,
+        "interest_rate": 0,
+        "loan_years": 1,
+        "property_tax": 0,
+        "insurance": 0,
+        "maintenance": 0,
+        "vacancy_rate": 0,
+        "rent": 0,
+        "appreciation_rate": 0,
+        "stock_return_rate": 0,
+        "years": 1,
+    }
+    resp = client.post("/local_llm", json={"scenario": scenario, "question": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["response"] == "dummy"

--- a/instructions.md
+++ b/instructions.md
@@ -272,8 +272,17 @@ uvicorn app.main:app --reload
   scikit-learn
   xgboost
   openai
+  huggingface-hub
+  llama-cpp-python
   requests
   ```
+
+### Local LLM Mode
+
+The backend includes `local_llm.py` which uses `llama-cpp-python` to run a
+quantized TinyLlama model on CPU. The first request to `/local_llm` downloads the
+weights from Hugging Face into `backend/models/`. This approach keeps the code
+modular so you can swap in larger models or GPU acceleration later.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `local_llm.py` with TinyLlama download and generation helpers
- expose new `/local_llm` endpoint in `main.py`
- update tests to cover local LLM usage
- document local model usage in README and instructions
- add `huggingface-hub` and `llama-cpp-python` to backend requirements
- clean up existing `llm.py`

## Testing
- `python3 -m venv venv && source venv/bin/activate && pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1f6ada20832197446b47da18f242